### PR TITLE
The scope of unsafe blocks can be appropriately reduced

### DIFF
--- a/core/src/thread_parker/windows/keyed_event.rs
+++ b/core/src/thread_parker/windows/keyed_event.rs
@@ -55,25 +55,24 @@ impl KeyedEvent {
 
     #[allow(non_snake_case)]
     pub fn create() -> Option<KeyedEvent> {
-        unsafe {
-            let ntdll = GetModuleHandleA(b"ntdll.dll\0".as_ptr());
+            let ntdll = unsafe { GetModuleHandleA(b"ntdll.dll\0".as_ptr()) };
             if ntdll == 0 {
                 return None;
             }
 
             let NtCreateKeyedEvent =
-                GetProcAddress(ntdll, b"NtCreateKeyedEvent\0".as_ptr())?;
+                unsafe { GetProcAddress(ntdll, b"NtCreateKeyedEvent\0".as_ptr())? };
             let NtReleaseKeyedEvent =
-                GetProcAddress(ntdll, b"NtReleaseKeyedEvent\0".as_ptr())?;
+                unsafe { GetProcAddress(ntdll, b"NtReleaseKeyedEvent\0".as_ptr())? };
             let NtWaitForKeyedEvent =
-                GetProcAddress(ntdll, b"NtWaitForKeyedEvent\0".as_ptr())?;
+                unsafe { GetProcAddress(ntdll, b"NtWaitForKeyedEvent\0".as_ptr())? };
 
             let NtCreateKeyedEvent: extern "system" fn(
                 KeyedEventHandle: *mut HANDLE,
                 DesiredAccess: u32,
                 ObjectAttributes: *mut ffi::c_void,
                 Flags: u32,
-            ) -> NTSTATUS = mem::transmute(NtCreateKeyedEvent);
+            ) -> NTSTATUS = unsafe { mem::transmute(NtCreateKeyedEvent) };
             let mut handle = MaybeUninit::uninit();
             let status = NtCreateKeyedEvent(
                 handle.as_mut_ptr(),
@@ -86,11 +85,10 @@ impl KeyedEvent {
             }
 
             Some(KeyedEvent {
-                handle: handle.assume_init(),
-                NtReleaseKeyedEvent: mem::transmute(NtReleaseKeyedEvent),
-                NtWaitForKeyedEvent: mem::transmute(NtWaitForKeyedEvent),
+                handle: unsafe { handle.assume_init() },
+                NtReleaseKeyedEvent: unsafe { mem::transmute(NtReleaseKeyedEvent) },
+                NtWaitForKeyedEvent: unsafe { mem::transmute(NtWaitForKeyedEvent) },
             })
-        }
     }
 
     #[inline]
@@ -174,10 +172,8 @@ impl KeyedEvent {
 impl Drop for KeyedEvent {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let ok = CloseHandle(self.handle);
+            let ok = unsafe { CloseHandle(self.handle) };
             debug_assert_eq!(ok, true.into());
-        }
     }
 }
 

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -136,7 +136,6 @@ impl Condvar {
 
     #[cold]
     fn notify_one_slow(&self, mutex: *mut RawMutex) -> bool {
-        unsafe {
             // Unpark one thread and requeue the rest onto the mutex
             let from = self as *const _ as usize;
             let to = mutex as usize;
@@ -156,7 +155,7 @@ impl Condvar {
                 // locking the queue. There is the possibility of a race if the
                 // mutex gets locked after we check, but that doesn't matter in
                 // this case.
-                if (*mutex).mark_parked_if_locked() {
+                if unsafe { (*mutex).mark_parked_if_locked() }{
                     RequeueOp::RequeueOne
                 } else {
                     RequeueOp::UnparkOne
@@ -169,10 +168,9 @@ impl Condvar {
                 }
                 TOKEN_NORMAL
             };
-            let res = parking_lot_core::unpark_requeue(from, to, validate, callback);
+            let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
 
             res.unparked_threads + res.requeued_threads != 0
-        }
     }
 
     /// Wakes up all blocked threads on this condvar.
@@ -197,7 +195,6 @@ impl Condvar {
 
     #[cold]
     fn notify_all_slow(&self, mutex: *mut RawMutex) -> usize {
-        unsafe {
             // Unpark one thread and requeue the rest onto the mutex
             let from = self as *const _ as usize;
             let to = mutex as usize;
@@ -221,7 +218,7 @@ impl Condvar {
                 // locking the queue. There is the possibility of a race if the
                 // mutex gets locked after we check, but that doesn't matter in
                 // this case.
-                if (*mutex).mark_parked_if_locked() {
+                if unsafe { (*mutex).mark_parked_if_locked() }{
                     RequeueOp::RequeueAll
                 } else {
                     RequeueOp::UnparkOneRequeueRest
@@ -231,14 +228,13 @@ impl Condvar {
                 // If we requeued threads to the mutex, mark it as having
                 // parked threads. The RequeueAll case is already handled above.
                 if op == RequeueOp::UnparkOneRequeueRest && result.requeued_threads != 0 {
-                    (*mutex).mark_parked();
+                    unsafe { (*mutex).mark_parked() };
                 }
                 TOKEN_NORMAL
             };
-            let res = parking_lot_core::unpark_requeue(from, to, validate, callback);
+            let res = unsafe { parking_lot_core::unpark_requeue(from, to, validate, callback) };
 
             res.unparked_threads + res.requeued_threads
-        }
     }
 
     /// Blocks the current thread until this condition variable receives a
@@ -297,7 +293,6 @@ impl Condvar {
     // This is a non-generic function to reduce the monomorphization cost of
     // using `wait_until`.
     fn wait_until_internal(&self, mutex: &RawMutex, timeout: Option<Instant>) -> WaitTimeoutResult {
-        unsafe {
             let result;
             let mut bad_mutex = false;
             let mut requeued = false;
@@ -319,7 +314,7 @@ impl Condvar {
                 };
                 let before_sleep = || {
                     // Unlock the mutex before sleeping...
-                    mutex.unlock();
+                    unsafe { mutex.unlock() };
                 };
                 let timed_out = |k, was_last_thread| {
                     // If we were requeued to a mutex, then we did not time out.
@@ -334,14 +329,14 @@ impl Condvar {
                         self.state.store(ptr::null_mut(), Ordering::Relaxed);
                     }
                 };
-                result = parking_lot_core::park(
+                result = unsafe { parking_lot_core::park(
                     addr,
                     validate,
                     before_sleep,
                     timed_out,
                     DEFAULT_PARK_TOKEN,
                     timeout,
-                );
+                ) };
             }
 
             // Panic if we tried to use multiple mutexes with a Condvar. Note
@@ -353,13 +348,12 @@ impl Condvar {
 
             // ... and re-lock it once we are done sleeping
             if result == ParkResult::Unparked(TOKEN_HANDOFF) {
-                deadlock::acquire_resource(mutex as *const _ as usize);
+                unsafe { deadlock::acquire_resource(mutex as *const _ as usize) };
             } else {
                 mutex.lock();
             }
 
             WaitTimeoutResult(!(result.is_unparked() || requeued))
-        }
     }
 
     /// Waits on this condition variable for a notification, timing out after a

--- a/src/once.rs
+++ b/src/once.rs
@@ -258,20 +258,19 @@ impl Once {
 
             // Park our thread until we are woken up by the thread that owns the
             // lock.
-            unsafe {
                 let addr = self as *const _ as usize;
                 let validate = || self.0.load(Ordering::Relaxed) == LOCKED_BIT | PARKED_BIT;
                 let before_sleep = || {};
                 let timed_out = |_, _| unreachable!();
-                parking_lot_core::park(
+                unsafe { 
+                    parking_lot_core::park(
                     addr,
                     validate,
                     before_sleep,
                     timed_out,
                     DEFAULT_PARK_TOKEN,
                     None,
-                );
-            }
+                ) };
 
             // Loop back and check if the done bit was set
             spinwait.reset();
@@ -285,8 +284,8 @@ impl Once {
                 let once = self.0;
                 let state = once.0.swap(POISON_BIT, Ordering::Release);
                 if state & PARKED_BIT != 0 {
+                    let addr = once as *const _ as usize;
                     unsafe {
-                        let addr = once as *const _ as usize;
                         parking_lot_core::unpark_all(addr, DEFAULT_UNPARK_TOKEN);
                     }
                 }
@@ -307,8 +306,8 @@ impl Once {
         // Now unlock the state, set the done bit and unpark all threads
         let state = self.0.swap(DONE_BIT, Ordering::Release);
         if state & PARKED_BIT != 0 {
+            let addr = self as *const _ as usize;
             unsafe {
-                let addr = self as *const _ as usize;
                 parking_lot_core::unpark_all(addr, DEFAULT_UNPARK_TOKEN);
             }
         }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 